### PR TITLE
Fix DloaderAdapter reusability issue

### DIFF
--- a/lib/src/adapters/aria2.dart
+++ b/lib/src/adapters/aria2.dart
@@ -18,7 +18,7 @@ class Aria2Adapter implements DloaderAdapter {
 
   /// The path to the aria2c executable.
   @override
-  late final String executablePath;
+  String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.
   Aria2Adapter() {
@@ -39,11 +39,11 @@ class Aria2Adapter implements DloaderAdapter {
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
   }) async {
-    executablePath = (await executable.find())!;
+    executablePath ??= (await executable.find())!;
     final filename = path.basename(destination.path);
     final directory = path.dirname(destination.path);
 
-    final process = await Process.start(executablePath, [
+    final process = await Process.start(executablePath!, [
       '--max-connection-per-server=$segments',
       '--split=$segments',
       '--min-split-size=1M',

--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -15,7 +15,7 @@ class AxelAdapter implements DloaderAdapter {
 
   /// The path to the axel executable.
   @override
-  late final String executablePath;
+  String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.
   AxelAdapter() {
@@ -35,13 +35,13 @@ class AxelAdapter implements DloaderAdapter {
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
   }) async {
-    executablePath = (await executable.find())!;
+    executablePath ??= (await executable.find())!;
 
     if (destination.existsSync()) {
       destination.deleteSync();
     }
 
-    final process = await Process.start(executablePath, [
+    final process = await Process.start(executablePath!, [
       url,
       '--num-connections=$segments',
       '--output=${destination.path}',

--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -17,7 +17,7 @@ class CurlAdapter implements DloaderAdapter {
 
   /// The path to the curl executable.
   @override
-  late final String executablePath;
+  String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.
   CurlAdapter() {
@@ -37,8 +37,8 @@ class CurlAdapter implements DloaderAdapter {
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
   }) async {
-    executablePath = (await executable.find())!;
-    final process = await Process.start(executablePath, [
+    executablePath ??= (await executable.find())!;
+    final process = await Process.start(executablePath!, [
       '--create-dirs',
       '--location',
       userAgent != null ? '--user-agent' : '',

--- a/lib/src/adapters/dio.dart
+++ b/lib/src/adapters/dio.dart
@@ -16,7 +16,7 @@ class DioAdapter implements DloaderAdapter {
 
   /// The path to the `cp` executable, which is here just to satisfy the [DloaderAdapter] interface.
   @override
-  late final String executablePath;
+  String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.
   DioAdapter() {

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -17,7 +17,7 @@ class PowerShellAdapter implements DloaderAdapter {
 
   /// The path to the powershell executable.
   @override
-  late final String executablePath;
+  String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.
   PowerShellAdapter() {
@@ -38,8 +38,8 @@ class PowerShellAdapter implements DloaderAdapter {
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
   }) async {
-    executablePath = (await executable.find())!;
-    final process = await Process.start(executablePath, [
+    executablePath ??= (await executable.find())!;
+    final process = await Process.start(executablePath!, [
       '-Command',
       'Start-BitsTransfer -Source $url -Destination ${destination.path} ${userAgent != null ? "-UserAgent $userAgent" : ""}}',
     ]);

--- a/lib/src/adapters/wget.dart
+++ b/lib/src/adapters/wget.dart
@@ -17,7 +17,7 @@ class WgetAdapter implements DloaderAdapter {
 
   /// The path to the wget executable.
   @override
-  late final String executablePath;
+  String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.
   WgetAdapter() {
@@ -37,8 +37,8 @@ class WgetAdapter implements DloaderAdapter {
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
   }) async {
-    executablePath = (await executable.find())!;
-    final process = await Process.start(executablePath, [
+    executablePath ??= (await executable.find())!;
+    final process = await Process.start(executablePath!, [
       '--continue',
       '--output-document=${destination.path}',
       userAgent != null ? '--user-agent=$userAgent' : '',

--- a/lib/src/dloader_adapter.dart
+++ b/lib/src/dloader_adapter.dart
@@ -11,7 +11,7 @@ abstract class DloaderAdapter {
   late final bool isAvailable;
 
   /// Path to the executable.
-  late final String executablePath;
+  String? executablePath;
 
   /// Downloads the file from the given [url] to the specified [destination] file.
   ///

--- a/test/dloader_test.dart
+++ b/test/dloader_test.dart
@@ -36,4 +36,33 @@ void main() {
       );
     }, throwsException);
   });
+
+  test('Test Dloader reuse CurlAdapter', () async {
+    final adapter = CurlAdapter();
+    if (!adapter.isAvailable) {
+      print('Skipping test: curl not available');
+      return;
+    }
+    final dloader = Dloader(adapter);
+    final url = 'https://www.google.com';
+    final destination1 = File('test_1.html');
+    final destination2 = File('test_2.html');
+
+    try {
+      await dloader.download(
+        url: url,
+        destination: destination1,
+      );
+      expect(destination1.existsSync(), true);
+
+      await dloader.download(
+        url: url,
+        destination: destination2,
+      );
+      expect(destination2.existsSync(), true);
+    } finally {
+      if (destination1.existsSync()) destination1.deleteSync();
+      if (destination2.existsSync()) destination2.deleteSync();
+    }
+  });
 }


### PR DESCRIPTION
Changed executablePath in DloaderAdapter and all adapter implementations from late final to nullable String? and added lazy initialization. This prevents LateInitializationError when reusing an adapter for multiple downloads. Added a test case for CurlAdapter reusability.

---
*PR created automatically by Jules for task [9745772086284424063](https://jules.google.com/task/9745772086284424063) started by @insign*