### PR TITLE
Fix CurlAdapter progress reporting

### DIFF
--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -48,10 +48,12 @@ class CurlAdapter implements DloaderAdapter {
       url,
     ]);
 
-    await for (var data in process.stdout.transform(utf8.decoder)) {
-      final lines = data.split('\n');
+    await for (var data in process.stderr.transform(utf8.decoder)) {
+      final lines = data.split(RegExp(r'[\n\r]'));
       for (final line in lines) {
-        onProgress?.call(parseProgress(line));
+        if (line.isNotEmpty) {
+          onProgress?.call(parseProgress(line));
+        }
       }
     }
 
@@ -62,7 +64,7 @@ class CurlAdapter implements DloaderAdapter {
   Map<String, String> parseProgress(String progressString) {
     final Map<String, String> progress = {};
     final match = RegExp(
-      r'(\d+)\s+([\w.]+)\s+(\d+)\s+([\w.]+)\s+(\d+)\s+(\d+)\s+([\w.]+)\s+(\d+)\s+([0-9:]+)\s+([0-9:]+)\s+([0-9:]+)\s+([\w.]+)',
+      r'(\d+)\s+([\w.]+)\s+(\d+)\s+([\w.]+)\s+(\d+)\s+(\d+)\s+([\w.]+)\s+(\d+)\s+([0-9:-]+)\s+([0-9:-]+)\s+([0-9:-]+)\s+([\w.]+)',
     ).firstMatch(progressString);
     if (match != null && match.groupCount == 12) {
       progress["percentComplete"] = match.group(1)!;

--- a/test/dloader_test.dart
+++ b/test/dloader_test.dart
@@ -65,4 +65,31 @@ void main() {
       if (destination2.existsSync()) destination2.deleteSync();
     }
   });
+
+  test('Test Dloader with CurlAdapter and valid URL with progress', () async {
+    final adapter = CurlAdapter();
+    if (!adapter.isAvailable) {
+      print('Skipping test: curl not available');
+      return;
+    }
+    final dloader = Dloader(adapter);
+    final url = 'https://proof.ovh.net/files/1Mb.dat';
+    final destination = File('${Directory.systemTemp.path}/curl_1Mb.dat');
+
+    bool progressCalled = false;
+    final file = await dloader.download(
+      url: url,
+      destination: destination,
+      onProgress: (progress) {
+        if (progress.containsKey('percentComplete')) {
+          progressCalled = true;
+          print('Curl Percent complete: ${progress['percentComplete']}%');
+        }
+      },
+    );
+
+    expect(file.existsSync(), true);
+    expect(file.lengthSync(), 1048576);
+    expect(progressCalled, true);
+  });
 }


### PR DESCRIPTION
Modified CurlAdapter to capture progress from stderr instead of stdout, as curl writes progress to stderr. Updated the progress parsing regex to handle variable time formats (e.g. --:--:--). Implemented logic to split output by both newline and carriage return to correctly parse progress updates. Added a test case to verify CurlAdapter progress reporting.

---
*PR created automatically by Jules for task [11515261198742114583](https://jules.google.com/task/11515261198742114583) started by @insign*