### PR TITLE
Add Dloader.auto factory and refactor adapter imports

### DIFF
--- a/lib/src/adapters/aria2.dart
+++ b/lib/src/adapters/aria2.dart
@@ -2,9 +2,10 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dloader/src/dloader_adapter.dart';
 import 'package:executable/executable.dart';
 import 'package:path/path.dart' as path;
+
+import '../dloader_adapter.dart';
 
 /// This class implements the [DloaderAdapter] interface and is used to download files using the `aria2c` executable.
 class Aria2Adapter implements DloaderAdapter {

--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:dloader/dloader.dart';
 import 'package:executable/executable.dart';
+
+import '../dloader_adapter.dart';
 
 /// This class implements [DloaderAdapter] for downloading using axel.
 class AxelAdapter implements DloaderAdapter {

--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -2,8 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dloader/src/dloader_adapter.dart';
 import 'package:executable/executable.dart';
+
+import '../dloader_adapter.dart';
 
 /// This class implements [DloaderAdapter] for downloading using curl.
 class CurlAdapter implements DloaderAdapter {

--- a/lib/src/adapters/dio.dart
+++ b/lib/src/adapters/dio.dart
@@ -1,8 +1,9 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
-import 'package:dloader/src/dloader_adapter.dart';
 import 'package:executable/executable.dart';
+
+import '../dloader_adapter.dart';
 
 /// This class implements the [DloaderAdapter] interface for downloading using [Dio].
 class DioAdapter implements DloaderAdapter {

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -2,8 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dloader/dloader.dart';
 import 'package:executable/executable.dart';
+
+import '../dloader_adapter.dart';
 
 /// This class implements [DloaderAdapter] for downloading using powershell.
 class PowerShellAdapter implements DloaderAdapter {

--- a/lib/src/adapters/wget.dart
+++ b/lib/src/adapters/wget.dart
@@ -2,8 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dloader/dloader.dart';
 import 'package:executable/executable.dart';
+
+import '../dloader_adapter.dart';
 
 /// This class implements [DloaderAdapter] for downloading using wget.
 class WgetAdapter implements DloaderAdapter {

--- a/lib/src/dloader_base.dart
+++ b/lib/src/dloader_base.dart
@@ -1,6 +1,12 @@
 import 'dart:io';
 
-import 'package:dloader/src/dloader_adapter.dart';
+import 'adapters/aria2.dart';
+import 'adapters/axel.dart';
+import 'adapters/curl.dart';
+import 'adapters/dio.dart';
+import 'adapters/powershell.dart';
+import 'adapters/wget.dart';
+import 'dloader_adapter.dart';
 
 /// A class that allows downloading a file from a URL, with an adapter implementation
 class Dloader {
@@ -16,6 +22,33 @@ class Dloader {
 
   /// Constructor for Dloader class
   Dloader(this.adapter);
+
+  /// Automatically selects the best available adapter.
+  ///
+  /// The order of preference is:
+  /// 1. Aria2
+  /// 2. Axel
+  /// 3. Wget
+  /// 4. Curl
+  /// 5. PowerShell
+  /// 6. Dio (always available)
+  factory Dloader.auto() {
+    final adapters = <DloaderAdapter>[
+      Aria2Adapter(),
+      AxelAdapter(),
+      WgetAdapter(),
+      CurlAdapter(),
+      PowerShellAdapter(),
+    ];
+
+    for (final adapter in adapters) {
+      if (adapter.isAvailable) {
+        return Dloader(adapter);
+      }
+    }
+
+    return Dloader(DioAdapter());
+  }
 
   /// Downloads a file from the given URL to the specified destination, using the adapter implementation
   ///

--- a/test/dloader_test.dart
+++ b/test/dloader_test.dart
@@ -90,4 +90,29 @@ void main() {
       if (destination.existsSync()) destination.deleteSync();
     }
   });
+
+  test('Test Dloader.auto()', () async {
+    final dloader = Dloader.auto();
+    final url = 'https://proof.ovh.net/files/1Mb.dat';
+    final destination = File('${Directory.systemTemp.path}/auto_1Mb.dat');
+
+    print('Using adapter: ${dloader.adapter.runtimeType}');
+
+    try {
+      final file = await dloader.download(
+        url: url,
+        destination: destination,
+        onProgress: (progress) {
+          // print('Percent complete: ${progress['percentComplete']}%');
+        },
+      );
+
+      expect(file.existsSync(), true);
+      expect(file.lengthSync(), 1048576);
+    } finally {
+      if (destination.existsSync()) {
+        destination.deleteSync();
+      }
+    }
+  });
 }


### PR DESCRIPTION
Added `Dloader.auto()` factory constructor to automatically select the best available download adapter.
Refactored adapter imports to use relative paths (`../dloader_adapter.dart`) to avoid circular dependencies and improve code quality.
Added unit test for `Dloader.auto()`.

---
*PR created automatically by Jules for task [16402936005201107719](https://jules.google.com/task/16402936005201107719) started by @insign*