### PR TITLE
Add Dloader.auto() for automatic adapter selection

### DIFF
--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:dloader/dloader.dart';
+import '../dloader_adapter.dart';
 import 'package:executable/executable.dart';
 
 /// This class implements [DloaderAdapter] for downloading using axel.

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dloader/dloader.dart';
+import '../dloader_adapter.dart';
 import 'package:executable/executable.dart';
 
 /// This class implements [DloaderAdapter] for downloading using powershell.

--- a/lib/src/adapters/wget.dart
+++ b/lib/src/adapters/wget.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dloader/dloader.dart';
+import '../dloader_adapter.dart';
 import 'package:executable/executable.dart';
 
 /// This class implements [DloaderAdapter] for downloading using wget.

--- a/lib/src/dloader_base.dart
+++ b/lib/src/dloader_base.dart
@@ -2,6 +2,13 @@ import 'dart:io';
 
 import 'package:dloader/src/dloader_adapter.dart';
 
+import 'adapters/aria2.dart';
+import 'adapters/axel.dart';
+import 'adapters/curl.dart';
+import 'adapters/dio.dart';
+import 'adapters/powershell.dart';
+import 'adapters/wget.dart';
+
 /// A class that allows downloading a file from a URL, with an adapter implementation
 class Dloader {
   /// The user agent to use when downloading the file
@@ -16,6 +23,26 @@ class Dloader {
 
   /// Constructor for Dloader class
   Dloader(this.adapter);
+
+  /// Automatically selects the best available adapter
+  factory Dloader.auto() {
+    final adapters = [
+      Aria2Adapter(),
+      AxelAdapter(),
+      WgetAdapter(),
+      CurlAdapter(),
+      PowerShellAdapter(),
+      DioAdapter(),
+    ];
+
+    for (final adapter in adapters) {
+      if (adapter.isAvailable) {
+        return Dloader(adapter);
+      }
+    }
+
+    return Dloader(DioAdapter());
+  }
 
   /// Downloads a file from the given URL to the specified destination, using the adapter implementation
   ///

--- a/test/dloader_auto_test.dart
+++ b/test/dloader_auto_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:dloader/dloader.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Test Dloader.auto() selects an available adapter', () {
+    final dloader = Dloader.auto();
+    expect(dloader.adapter, isNotNull);
+    expect(dloader.adapter.isAvailable, isTrue);
+    print('Selected adapter: ${dloader.adapter.runtimeType}');
+  });
+
+  test('Test Dloader.auto() download', () async {
+    final dloader = Dloader.auto();
+    final url = 'https://proof.ovh.net/files/1Mb.dat';
+    final destination = File('${Directory.systemTemp.path}/1Mb_auto.dat');
+
+    // Ensure cleanup
+    if (destination.existsSync()) {
+      destination.deleteSync();
+    }
+
+    try {
+      final file = await dloader.download(
+        url: url,
+        destination: destination,
+        onProgress: (progress) {
+          // print('Percent complete: ${progress['percentComplete']}%');
+        },
+      );
+
+      expect(file.existsSync(), true);
+      expect(file.lengthSync(), 1048576);
+    } finally {
+      if (destination.existsSync()) {
+        destination.deleteSync();
+      }
+    }
+  });
+}


### PR DESCRIPTION
Added `Dloader.auto()` factory constructor to automatically select the best available download adapter. This simplifies usage by not requiring the user to manually instantiate an adapter.
Refactored imports in several adapter files to prevent circular dependencies.
Added unit tests for the new feature.

---
*PR created automatically by Jules for task [1201407770980881632](https://jules.google.com/task/1201407770980881632) started by @insign*