### PR TITLE
fix: make Dloader.onProgress usable and fix its type

### DIFF
--- a/lib/src/dloader_base.dart
+++ b/lib/src/dloader_base.dart
@@ -15,7 +15,7 @@ class Dloader {
       'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36';
 
   /// The callback that will be called on every progress update
-  Function(double, int)? onProgress;
+  Function(Map<String, dynamic>)? onProgress;
 
   /// The adapter implementation that will perform the download
   DloaderAdapter adapter;
@@ -87,7 +87,7 @@ class Dloader {
       destination: destination,
       userAgent: userAgent,
       segments: segments,
-      onProgress: onProgress,
+      onProgress: onProgress ?? this.onProgress,
     );
   }
 }

--- a/test/dloader_test.dart
+++ b/test/dloader_test.dart
@@ -115,4 +115,30 @@ void main() {
       }
     }
   });
+
+  test('Test Dloader with default onProgress', () async {
+    final dloader = Dloader(DioAdapter());
+    final url = 'https://proof.ovh.net/files/1Mb.dat';
+    final destination = File('${Directory.systemTemp.path}/default_onProgress_1Mb.dat');
+
+    bool progressCalled = false;
+    dloader.onProgress = (progress) {
+      if (progress.containsKey('percentComplete')) {
+        progressCalled = true;
+      }
+    };
+
+    try {
+      final file = await dloader.download(
+        url: url,
+        destination: destination,
+      );
+
+      expect(file.existsSync(), true);
+      expect(file.lengthSync(), 1048576);
+      expect(progressCalled, true);
+    } finally {
+      if (destination.existsSync()) destination.deleteSync();
+    }
+  });
 }


### PR DESCRIPTION
The `Dloader` class had an `onProgress` field that was typed incorrectly (`Function(double, int)?`) and was not used by the `download` method.

This change:
- Changes the `onProgress` field type to `Function(Map<String, dynamic>)?` to match the `DloaderAdapter` interface and the `download` method signature.
- Updates the `download` method to use the instance's `onProgress` callback if no callback is provided in the method call.
- Adds a test case to verify that the default `onProgress` callback is called.

---
*PR created automatically by Jules for task [13745289034263746958](https://jules.google.com/task/13745289034263746958) started by @insign*