### PR TITLE
Fix Dloader.onProgress type and usage fallback

### DIFF
--- a/lib/src/dloader_base.dart
+++ b/lib/src/dloader_base.dart
@@ -15,7 +15,7 @@ class Dloader {
       'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36';
 
   /// The callback that will be called on every progress update
-  Function(double, int)? onProgress;
+  Function(Map<String, dynamic>)? onProgress;
 
   /// The adapter implementation that will perform the download
   DloaderAdapter adapter;
@@ -87,7 +87,7 @@ class Dloader {
       destination: destination,
       userAgent: userAgent,
       segments: segments,
-      onProgress: onProgress,
+      onProgress: onProgress ?? this.onProgress,
     );
   }
 }

--- a/test/dloader_on_progress_test.dart
+++ b/test/dloader_on_progress_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+import 'package:dloader/dloader.dart';
+import 'package:executable/executable.dart';
+import 'package:test/test.dart';
+
+class MockAdapter implements DloaderAdapter {
+  @override
+  Executable executable = Executable('mock');
+
+  @override
+  bool isAvailable = true;
+
+  @override
+  String? executablePath = '/bin/mock';
+
+  @override
+  Future<File> download({
+    required String url,
+    required File destination,
+    String? userAgent,
+    int? segments,
+    Function(Map<String, dynamic>)? onProgress,
+  }) async {
+    // Simulate progress
+    if (onProgress != null) {
+      onProgress({'percentComplete': '50', 'downloaded': '100', 'totalSize': '200'});
+    }
+    return destination;
+  }
+}
+
+void main() {
+  test('Dloader uses instance onProgress as fallback', () async {
+    final adapter = MockAdapter();
+    final dloader = Dloader(adapter);
+    bool instanceProgressCalled = false;
+
+    dloader.onProgress = (Map<String, dynamic> progress) {
+       instanceProgressCalled = true;
+       expect(progress['percentComplete'], '50');
+    };
+
+    await dloader.download(
+      url: 'http://example.com',
+      destination: File('test_file'),
+    );
+
+    expect(instanceProgressCalled, isTrue, reason: 'Instance onProgress should be called');
+  });
+
+  test('Dloader uses passed onProgress over instance onProgress', () async {
+    final adapter = MockAdapter();
+    final dloader = Dloader(adapter);
+    bool instanceProgressCalled = false;
+    bool argProgressCalled = false;
+
+    dloader.onProgress = (Map<String, dynamic> progress) {
+       instanceProgressCalled = true;
+    };
+
+    await dloader.download(
+      url: 'http://example.com',
+      destination: File('test_file'),
+      onProgress: (progress) {
+        argProgressCalled = true;
+      }
+    );
+
+    expect(argProgressCalled, isTrue, reason: 'Argument onProgress should be called');
+    expect(instanceProgressCalled, isFalse, reason: 'Instance onProgress should NOT be called');
+  });
+}


### PR DESCRIPTION
This PR fixes an issue where the `Dloader.onProgress` instance field had an incorrect type signature (`Function(double, int)?`) compared to what the adapters and `download` method expect (`Function(Map<String, dynamic>)?`). 

Additionally, the `onProgress` instance field was previously ignored by the `download` method. This change ensures that if no `onProgress` callback is provided to `download`, the instance's `onProgress` callback is used as a fallback.

This is a breaking change for anyone who was setting `dloader.onProgress` with the old signature, but since it was not being used, it likely had no effect previously.

---
*PR created automatically by Jules for task [16065508692530482370](https://jules.google.com/task/16065508692530482370) started by @insign*