### PR TITLE
Add timeout parameter to download method

### DIFF
--- a/lib/src/adapters/aria2.dart
+++ b/lib/src/adapters/aria2.dart
@@ -41,6 +41,7 @@ class Aria2Adapter implements DloaderAdapter {
     String? userAgent,
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
+    Duration? timeout,
   }) async {
     executablePath ??= (await executable.find())!;
     final filename = path.basename(destination.path);
@@ -54,6 +55,8 @@ class Aria2Adapter implements DloaderAdapter {
       '--out=$filename',
       '--file-allocation=falloc',
       if (userAgent != null) '--user-agent=$userAgent',
+      if (timeout != null)
+        '--timeout=${(timeout.inMilliseconds / 1000).ceil()}',
       '--continue=true',
       '--auto-file-renaming=false',
       '--allow-overwrite=true',

--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -37,6 +37,7 @@ class AxelAdapter implements DloaderAdapter {
     String? userAgent,
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
+    Duration? timeout,
   }) async {
     executablePath ??= (await executable.find())!;
 
@@ -50,6 +51,8 @@ class AxelAdapter implements DloaderAdapter {
       '--output=${destination.path}',
       '--percentage',
       if (userAgent != null) '--user-agent=$userAgent',
+      if (timeout != null)
+        '--timeout=${(timeout.inMilliseconds / 1000).ceil()}',
     ];
 
     if (headers != null) {

--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -39,12 +39,17 @@ class CurlAdapter implements DloaderAdapter {
     String? userAgent,
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
+    Duration? timeout,
   }) async {
     executablePath ??= (await executable.find())!;
     final args = [
       '--create-dirs',
       '--location',
       if (userAgent != null) ...['--user-agent', userAgent],
+      if (timeout != null) ...[
+        '--max-time',
+        (timeout.inMilliseconds / 1000).toString(),
+      ],
       '--output',
       destination.path,
     ];

--- a/lib/src/adapters/dio.dart
+++ b/lib/src/adapters/dio.dart
@@ -38,8 +38,13 @@ class DioAdapter implements DloaderAdapter {
     String? userAgent,
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
+    Duration? timeout,
   }) async {
     final dio = Dio();
+    if (timeout != null) {
+      dio.options.connectTimeout = timeout;
+      dio.options.receiveTimeout = timeout;
+    }
     final requestHeaders = Map<String, dynamic>.from(headers ?? {});
     if (userAgent != null) {
       requestHeaders["User-Agent"] = userAgent;

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -40,7 +40,13 @@ class PowerShellAdapter implements DloaderAdapter {
     String? userAgent,
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
+    Duration? timeout,
   }) async {
+    if (timeout != null) {
+      print(
+        'Warning: Timeout is not supported by PowerShellAdapter (Start-BitsTransfer). It will be ignored.',
+      );
+    }
     if (headers != null && headers.isNotEmpty) {
       print(
         'Warning: Custom headers are not supported by PowerShellAdapter (Start-BitsTransfer). They will be ignored.',

--- a/lib/src/adapters/wget.dart
+++ b/lib/src/adapters/wget.dart
@@ -39,12 +39,15 @@ class WgetAdapter implements DloaderAdapter {
     String? userAgent,
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
+    Duration? timeout,
   }) async {
     executablePath ??= (await executable.find())!;
     final args = [
       '--continue',
       '--output-document=${destination.path}',
       if (userAgent != null) '--user-agent=$userAgent',
+      if (timeout != null)
+        '--timeout=${(timeout.inMilliseconds / 1000).ceil()}',
       '--progress=bar:force',
     ];
 

--- a/lib/src/dloader_adapter.dart
+++ b/lib/src/dloader_adapter.dart
@@ -30,5 +30,6 @@ abstract class DloaderAdapter {
     String? userAgent,
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
+    Duration? timeout,
   });
 }

--- a/lib/src/dloader_base.dart
+++ b/lib/src/dloader_base.dart
@@ -61,6 +61,7 @@ class Dloader {
   /// [segments] The number of segments to download the file in.
   /// [onProgress] The callback that will be called on every progress update.
   /// [retries] The number of times to retry the download if it fails. Defaults to 0.
+  /// [timeout] The maximum duration to wait for the download to complete.
   Future<File> download({
     required String url,
     required File destination,
@@ -70,6 +71,7 @@ class Dloader {
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
     int retries = 0,
+    Duration? timeout,
   }) async {
     if (!adapter.isAvailable) {
       throw Exception(
@@ -98,6 +100,7 @@ class Dloader {
           userAgent: userAgent,
           segments: segments,
           onProgress: onProgress ?? this.onProgress,
+          timeout: timeout,
         );
       } catch (e) {
         if (attempts > retries) {

--- a/test/dloader_on_progress_test.dart
+++ b/test/dloader_on_progress_test.dart
@@ -21,10 +21,15 @@ class MockAdapter implements DloaderAdapter {
     String? userAgent,
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
+    Duration? timeout,
   }) async {
     // Simulate progress
     if (onProgress != null) {
-      onProgress({'percentComplete': '50', 'downloaded': '100', 'totalSize': '200'});
+      onProgress({
+        'percentComplete': '50',
+        'downloaded': '100',
+        'totalSize': '200',
+      });
     }
     return destination;
   }
@@ -37,8 +42,8 @@ void main() {
     bool instanceProgressCalled = false;
 
     dloader.onProgress = (Map<String, dynamic> progress) {
-       instanceProgressCalled = true;
-       expect(progress['percentComplete'], '50');
+      instanceProgressCalled = true;
+      expect(progress['percentComplete'], '50');
     };
 
     await dloader.download(
@@ -46,7 +51,11 @@ void main() {
       destination: File('test_file'),
     );
 
-    expect(instanceProgressCalled, isTrue, reason: 'Instance onProgress should be called');
+    expect(
+      instanceProgressCalled,
+      isTrue,
+      reason: 'Instance onProgress should be called',
+    );
   });
 
   test('Dloader uses passed onProgress over instance onProgress', () async {
@@ -56,7 +65,7 @@ void main() {
     bool argProgressCalled = false;
 
     dloader.onProgress = (Map<String, dynamic> progress) {
-       instanceProgressCalled = true;
+      instanceProgressCalled = true;
     };
 
     await dloader.download(
@@ -64,10 +73,18 @@ void main() {
       destination: File('test_file'),
       onProgress: (progress) {
         argProgressCalled = true;
-      }
+      },
     );
 
-    expect(argProgressCalled, isTrue, reason: 'Argument onProgress should be called');
-    expect(instanceProgressCalled, isFalse, reason: 'Instance onProgress should NOT be called');
+    expect(
+      argProgressCalled,
+      isTrue,
+      reason: 'Argument onProgress should be called',
+    );
+    expect(
+      instanceProgressCalled,
+      isFalse,
+      reason: 'Instance onProgress should NOT be called',
+    );
   });
 }

--- a/test/dloader_retry_test.dart
+++ b/test/dloader_retry_test.dart
@@ -27,6 +27,7 @@ class FailingAdapter implements DloaderAdapter {
     String? userAgent,
     int? segments,
     Function(Map<String, dynamic>)? onProgress,
+    Duration? timeout,
   }) async {
     attempts++;
     if (attempts <= failsCount) {

--- a/test/dloader_test.dart
+++ b/test/dloader_test.dart
@@ -143,7 +143,9 @@ void main() {
   test('Test Dloader with default onProgress', () async {
     final dloader = Dloader(DioAdapter());
     final url = 'https://proof.ovh.net/files/1Mb.dat';
-    final destination = File('${Directory.systemTemp.path}/default_progress.dat');
+    final destination = File(
+      '${Directory.systemTemp.path}/default_progress.dat',
+    );
     bool progressCalled = false;
 
     dloader.onProgress = (progress) {
@@ -153,10 +155,7 @@ void main() {
     };
 
     try {
-      final file = await dloader.download(
-        url: url,
-        destination: destination,
-      );
+      final file = await dloader.download(url: url, destination: destination);
 
       expect(file.existsSync(), true);
       expect(file.lengthSync(), 1048576);

--- a/test/timeout_test.dart
+++ b/test/timeout_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:dloader/dloader.dart';
+import 'package:dio/dio.dart';
+
+void main() {
+  test('Test Dloader with timeout', () async {
+    final dloader = Dloader(DioAdapter());
+    // URL that delays response by 5 seconds
+    final url = 'https://httpbin.org/delay/5';
+    final destination = File('${Directory.systemTemp.path}/timeout_test.json');
+
+    try {
+      await dloader.download(
+        url: url,
+        destination: destination,
+        timeout: Duration(seconds: 2),
+      );
+      fail('Should have timed out');
+    } catch (e) {
+      print('Download failed as expected: $e');
+      // Dio throws DioException on timeout
+      if (e is DioException) {
+        expect(
+          e.type == DioExceptionType.connectionTimeout ||
+              e.type == DioExceptionType.receiveTimeout,
+          true,
+        );
+      } else {
+        // Should throw some exception
+        expect(e, isNotNull);
+      }
+    } finally {
+      if (destination.existsSync()) {
+        destination.deleteSync();
+      }
+    }
+  }, timeout: Timeout(Duration(seconds: 10)));
+}


### PR DESCRIPTION
Added a `timeout` parameter to the `download` method to allow users to specify a maximum duration for downloads. This feature is implemented across all supported adapters (Dio, Curl, Wget, Aria2, Axel), with a graceful fallback/warning for PowerShell.

---
*PR created automatically by Jules for task [13149903208387352799](https://jules.google.com/task/13149903208387352799) started by @insign*