### PR TITLE
Fix CLI adapters to throw exception on failure exit codes

### DIFF
--- a/lib/src/adapters/aria2.dart
+++ b/lib/src/adapters/aria2.dart
@@ -81,6 +81,11 @@ class Aria2Adapter implements DloaderAdapter {
       }
     }
 
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('aria2c exited with code $exitCode');
+    }
+
     return destination;
   }
 

--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -67,6 +67,11 @@ class AxelAdapter implements DloaderAdapter {
       }
     }
 
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('axel exited with code $exitCode');
+    }
+
     return destination;
   }
 

--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -44,6 +44,7 @@ class CurlAdapter implements DloaderAdapter {
     final args = [
       '--create-dirs',
       '--location',
+      '--fail',
       if (userAgent != null) ...['--user-agent', userAgent],
       '--output',
       destination.path,
@@ -67,6 +68,11 @@ class CurlAdapter implements DloaderAdapter {
           onProgress?.call(parseProgress(line));
         }
       }
+    }
+
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('curl exited with code $exitCode');
     }
 
     return destination;

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -59,6 +59,11 @@ class PowerShellAdapter implements DloaderAdapter {
       }
     }
 
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('powershell exited with code $exitCode');
+    }
+
     return destination;
   }
 

--- a/lib/src/adapters/wget.dart
+++ b/lib/src/adapters/wget.dart
@@ -65,6 +65,11 @@ class WgetAdapter implements DloaderAdapter {
       }
     }
 
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('wget exited with code $exitCode');
+    }
+
     return destination;
   }
 

--- a/test/dloader_cli_failure_test.dart
+++ b/test/dloader_cli_failure_test.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:dloader/dloader.dart';
+
+void main() {
+  test('Test Dloader with CurlAdapter throws exception on invalid URL', () async {
+    final adapter = CurlAdapter();
+    if (!adapter.isAvailable) {
+      print('Skipping test: curl not available');
+      return;
+    }
+    final dloader = Dloader(adapter);
+    final url = 'http://thisdomaindoesnotexist.local/file.dat';
+    final destination = File('${Directory.systemTemp.path}/curl_fail.dat');
+
+    expect(
+      () => dloader.download(url: url, destination: destination),
+      throwsException,
+    );
+  });
+
+  test('Test Dloader with WgetAdapter throws exception on invalid URL', () async {
+    final adapter = WgetAdapter();
+    if (!adapter.isAvailable) {
+      print('Skipping test: wget not available');
+      return;
+    }
+    final dloader = Dloader(adapter);
+    final url = 'http://thisdomaindoesnotexist.local/file.dat';
+    final destination = File('${Directory.systemTemp.path}/wget_fail.dat');
+
+    expect(
+      () => dloader.download(url: url, destination: destination),
+      throwsException,
+    );
+  });
+}


### PR DESCRIPTION
CLI adapters were previously ignoring the exit code of their respective subprocesses, meaning that if a download failed (due to network error, 404, invalid domain, etc.), the `Dloader` would falsely complete successfully instead of throwing an error or triggering a retry. This PR adds exit code checks and the `--fail` flag for curl to fix the issue. Tests have been added to verify the correct behavior.

---
*PR created automatically by Jules for task [2163780327918913850](https://jules.google.com/task/2163780327918913850) started by @insign*