### PR TITLE
Fix: Handle non-zero exit codes in CLI adapters

### DIFF
--- a/lib/src/adapters/aria2.dart
+++ b/lib/src/adapters/aria2.dart
@@ -81,6 +81,11 @@ class Aria2Adapter implements DloaderAdapter {
       }
     }
 
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('aria2c exited with code $exitCode');
+    }
+
     return destination;
   }
 

--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -67,6 +67,11 @@ class AxelAdapter implements DloaderAdapter {
       }
     }
 
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('axel exited with code $exitCode');
+    }
+
     return destination;
   }
 

--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -44,6 +44,7 @@ class CurlAdapter implements DloaderAdapter {
     final args = [
       '--create-dirs',
       '--location',
+      '--fail',
       if (userAgent != null) ...['--user-agent', userAgent],
       '--output',
       destination.path,
@@ -67,6 +68,11 @@ class CurlAdapter implements DloaderAdapter {
           onProgress?.call(parseProgress(line));
         }
       }
+    }
+
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('curl exited with code $exitCode');
     }
 
     return destination;

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -59,6 +59,11 @@ class PowerShellAdapter implements DloaderAdapter {
       }
     }
 
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('powershell exited with code $exitCode');
+    }
+
     return destination;
   }
 

--- a/lib/src/adapters/wget.dart
+++ b/lib/src/adapters/wget.dart
@@ -65,6 +65,11 @@ class WgetAdapter implements DloaderAdapter {
       }
     }
 
+    final exitCode = await process.exitCode;
+    if (exitCode != 0) {
+      throw Exception('wget exited with code $exitCode');
+    }
+
     return destination;
   }
 

--- a/test/dloader_test.dart
+++ b/test/dloader_test.dart
@@ -61,6 +61,44 @@ void main() {
     }
   });
 
+  test('Test Dloader with CurlAdapter and invalid URL', () async {
+    final adapter = CurlAdapter();
+    if (!adapter.isAvailable) {
+      print('Skipping test: curl not available');
+      return;
+    }
+
+    expect(() async {
+      final dloader = Dloader(adapter);
+      final url = 'https://invalid.supersite/file.dat';
+      final destination = File('${Directory.systemTemp.path}/curl_invalid.dat');
+
+      await dloader.download(
+        url: url,
+        destination: destination,
+      );
+    }, throwsException);
+  });
+
+  test('Test Dloader with WgetAdapter and invalid URL', () async {
+    final adapter = WgetAdapter();
+    if (!adapter.isAvailable) {
+      print('Skipping test: wget not available');
+      return;
+    }
+
+    expect(() async {
+      final dloader = Dloader(adapter);
+      final url = 'https://invalid.supersite/file.dat';
+      final destination = File('${Directory.systemTemp.path}/wget_invalid.dat');
+
+      await dloader.download(
+        url: url,
+        destination: destination,
+      );
+    }, throwsException);
+  });
+
   test('Test Dloader with CurlAdapter and valid URL with progress', () async {
     final adapter = CurlAdapter();
     if (!adapter.isAvailable) {


### PR DESCRIPTION
Ensures that all CLI adapters properly handle failures by throwing exceptions based on exit codes.

---
*PR created automatically by Jules for task [15978805189627577981](https://jules.google.com/task/15978805189627577981) started by @insign*