### PR TITLE
Refactor DloaderAdapter to remove CLI-specific fields

### DIFF
--- a/lib/src/adapters/aria2.dart
+++ b/lib/src/adapters/aria2.dart
@@ -10,7 +10,6 @@ import '../dloader_adapter.dart';
 /// This class implements the [DloaderAdapter] interface and is used to download files using the `aria2c` executable.
 class Aria2Adapter implements DloaderAdapter {
   /// The [Executable] object representing the `aria2c` executable.
-  @override
   Executable executable = Executable('aria2c');
 
   /// Whether the aria2c executable is available on the system.
@@ -18,7 +17,6 @@ class Aria2Adapter implements DloaderAdapter {
   late final bool isAvailable;
 
   /// The path to the aria2c executable.
-  @override
   String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.

--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -7,7 +7,6 @@ import '../dloader_adapter.dart';
 /// This class implements [DloaderAdapter] for downloading using axel.
 class AxelAdapter implements DloaderAdapter {
   /// The [Executable] object representing the `axel` executable.
-  @override
   Executable executable = Executable('axel');
 
   /// Whether the axel executable is available on the system.
@@ -15,7 +14,6 @@ class AxelAdapter implements DloaderAdapter {
   late final bool isAvailable;
 
   /// The path to the axel executable.
-  @override
   String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.

--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -9,7 +9,6 @@ import '../dloader_adapter.dart';
 /// This class implements [DloaderAdapter] for downloading using curl.
 class CurlAdapter implements DloaderAdapter {
   /// The [Executable] object representing the `curl` executable.
-  @override
   Executable executable = Executable('curl');
 
   /// Whether the curl executable is available on the system.
@@ -17,7 +16,6 @@ class CurlAdapter implements DloaderAdapter {
   late final bool isAvailable;
 
   /// The path to the curl executable.
-  @override
   String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.

--- a/lib/src/adapters/dio.dart
+++ b/lib/src/adapters/dio.dart
@@ -1,23 +1,14 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
-import 'package:executable/executable.dart';
 
 import '../dloader_adapter.dart';
 
 /// This class implements the [DloaderAdapter] interface for downloading using [Dio].
 class DioAdapter implements DloaderAdapter {
-  /// The [Executable] object representing the `cp` executable, which is here just to satisfy the [DloaderAdapter] interface.
-  @override
-  Executable executable = Executable('cp');
-
-  /// Whether the `cp` executable is available on the system, which is here just to satisfy the [DloaderAdapter] interface.
+  /// Whether the [Dio] adapter is available on the system.
   @override
   late final bool isAvailable;
-
-  /// The path to the `cp` executable, which is here just to satisfy the [DloaderAdapter] interface.
-  @override
-  String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.
   DioAdapter() {

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -9,7 +9,6 @@ import '../dloader_adapter.dart';
 /// This class implements [DloaderAdapter] for downloading using powershell.
 class PowerShellAdapter implements DloaderAdapter {
   /// The [Executable] object representing the `powershell` executable.
-  @override
   Executable executable = Executable('powershell');
 
   /// Whether the powershell executable is available on the system.
@@ -17,7 +16,6 @@ class PowerShellAdapter implements DloaderAdapter {
   late final bool isAvailable;
 
   /// The path to the powershell executable.
-  @override
   String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.

--- a/lib/src/adapters/wget.dart
+++ b/lib/src/adapters/wget.dart
@@ -9,7 +9,6 @@ import '../dloader_adapter.dart';
 /// This class implements [DloaderAdapter] for downloading using wget.
 class WgetAdapter implements DloaderAdapter {
   /// The [Executable] object representing the `wget` executable.
-  @override
   Executable executable = Executable('wget');
 
   /// Whether the wget executable is available on the system.
@@ -17,7 +16,6 @@ class WgetAdapter implements DloaderAdapter {
   late final bool isAvailable;
 
   /// The path to the wget executable.
-  @override
   String? executablePath;
 
   /// Constructor that initializes the [isAvailable] flag.

--- a/lib/src/dloader_adapter.dart
+++ b/lib/src/dloader_adapter.dart
@@ -1,17 +1,9 @@
 import 'dart:io';
 
-import 'package:executable/executable.dart';
-
 /// Abstract class for the download adapter used by [Dloader].
 abstract class DloaderAdapter {
-  /// Executable of the adapter.
-  late final Executable executable;
-
   /// Flag indicating if the adapter is available or not.
   late final bool isAvailable;
-
-  /// Path to the executable.
-  String? executablePath;
 
   /// Downloads the file from the given [url] to the specified [destination] file.
   ///

--- a/lib/src/dloader_base.dart
+++ b/lib/src/dloader_base.dart
@@ -73,7 +73,7 @@ class Dloader {
   }) async {
     if (!adapter.isAvailable) {
       throw Exception(
-        'Dloader adapter ${adapter.executable.cmd} not available',
+        'Dloader adapter ${adapter.runtimeType} not available',
       );
     }
 

--- a/test/dloader_on_progress_test.dart
+++ b/test/dloader_on_progress_test.dart
@@ -1,17 +1,10 @@
 import 'dart:io';
 import 'package:dloader/dloader.dart';
-import 'package:executable/executable.dart';
 import 'package:test/test.dart';
 
 class MockAdapter implements DloaderAdapter {
   @override
-  Executable executable = Executable('mock');
-
-  @override
   bool isAvailable = true;
-
-  @override
-  String? executablePath = '/bin/mock';
 
   @override
   Future<File> download({


### PR DESCRIPTION
Refactored the `DloaderAdapter` interface to remove the `executable` and `executablePath` properties that are only relevant to CLI-based adapters. This improves the abstraction by not forcing native Dart adapters (like `DioAdapter` or `MockAdapter` in tests) to implement dummy CLI properties to satisfy the interface. The properties were moved into the respective CLI adapters (`aria2.dart`, `axel.dart`, `curl.dart`, `powershell.dart`, `wget.dart`) that actually need them. Additionally, I updated the exception handling in `dloader_base.dart` to rely on `adapter.runtimeType` for building error messages rather than the CLI-specific `executable.cmd` property. All tests pass successfully with these changes.

---
*PR created automatically by Jules for task [3191472788075873928](https://jules.google.com/task/3191472788075873928) started by @insign*