### PR TITLE
feat: ensure destination directory exists before downloading

### DIFF
--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -42,7 +42,6 @@ class CurlAdapter implements DloaderAdapter {
   }) async {
     executablePath ??= (await executable.find())!;
     final args = [
-      '--create-dirs',
       '--location',
       '--fail',
       if (userAgent != null) ...['--user-agent', userAgent],

--- a/lib/src/dloader_base.dart
+++ b/lib/src/dloader_base.dart
@@ -87,6 +87,10 @@ class Dloader {
       throw Exception('URL not provided');
     }
 
+    if (!destination.parent.existsSync()) {
+      destination.parent.createSync(recursive: true);
+    }
+
     int attempts = 0;
     while (true) {
       try {

--- a/test/dloader_test.dart
+++ b/test/dloader_test.dart
@@ -202,4 +202,31 @@ void main() {
       }
     }
   });
+
+  test(
+    'Test Dloader creates destination directory if it does not exist',
+    () async {
+      final dloader = Dloader.auto();
+      final url = 'https://proof.ovh.net/files/1Mb.dat';
+      final dir = Directory(
+        '${Directory.systemTemp.path}/dloader_test_auto_dir',
+      );
+      final destination = File('${dir.path}/1Mb.dat');
+
+      try {
+        if (dir.existsSync()) {
+          dir.deleteSync(recursive: true);
+        }
+
+        final file = await dloader.download(url: url, destination: destination);
+
+        expect(file.existsSync(), true);
+        expect(file.lengthSync(), 1048576);
+      } finally {
+        if (dir.existsSync()) {
+          dir.deleteSync(recursive: true);
+        }
+      }
+    },
+  );
 }


### PR DESCRIPTION
This PR ensures the destination directory is uniformly created across all adapters.

Previously, adapters like `wget`, `axel`, and `powershell` would fail and throw an error if the parent directory of the destination file didn't exist. Only `curl` was explicitly instructed to create missing directories via the `--create-dirs` flag. 

By adding `destination.parent.createSync(recursive: true)` directly to the `Dloader.download` method in `lib/src/dloader_base.dart`, we ensure that the target directory is guaranteed to exist before delegating to the chosen adapter. This creates a unified, robust, and cross-platform interface regardless of which specific adapter is dynamically selected.

The redundant `--create-dirs` flag in `lib/src/adapters/curl.dart` has been removed. A new automated test case was also added to explicitly verify that downloading to a non-existent subdirectory behaves correctly.

---
*PR created automatically by Jules for task [17133611495879945986](https://jules.google.com/task/17133611495879945986) started by @insign*