### PR TITLE
fix: Use LineSplitter to correctly buffer CLI adapter outputs

### DIFF
--- a/lib/src/adapters/aria2.dart
+++ b/lib/src/adapters/aria2.dart
@@ -74,11 +74,11 @@ class Aria2Adapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var data in process.stdout.transform(utf8.decoder)) {
-      final lines = data.split('\n');
-      for (final line in lines) {
-        onProgress?.call(parseProgress(line));
-      }
+    await for (var line
+        in process.stdout
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())) {
+      onProgress?.call(parseProgress(line));
     }
 
     final exitCode = await process.exitCode;

--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -60,11 +60,11 @@ class AxelAdapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var data in process.stdout.transform(utf8.decoder)) {
-      final lines = data.split('\n');
-      for (final line in lines) {
-        onProgress?.call(parseProgress(line));
-      }
+    await for (var line
+        in process.stdout
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())) {
+      onProgress?.call(parseProgress(line));
     }
 
     final exitCode = await process.exitCode;

--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -60,12 +60,12 @@ class CurlAdapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var data in process.stderr.transform(utf8.decoder)) {
-      final lines = data.split(RegExp(r'[\n\r]'));
-      for (final line in lines) {
-        if (line.isNotEmpty) {
-          onProgress?.call(parseProgress(line));
-        }
+    await for (var line
+        in process.stderr
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())) {
+      if (line.isNotEmpty) {
+        onProgress?.call(parseProgress(line));
       }
     }
 

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -52,11 +52,11 @@ class PowerShellAdapter implements DloaderAdapter {
       'Start-BitsTransfer -Source $url -Destination ${destination.path} ${userAgent != null ? "-UserAgent $userAgent" : ""}}',
     ]);
 
-    await for (var data in process.stdout.transform(utf8.decoder)) {
-      final lines = data.split('\n');
-      for (final line in lines) {
-        onProgress?.call(parseProgress(line));
-      }
+    await for (var line
+        in process.stdout
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())) {
+      onProgress?.call(parseProgress(line));
     }
 
     final exitCode = await process.exitCode;

--- a/lib/src/adapters/wget.dart
+++ b/lib/src/adapters/wget.dart
@@ -58,11 +58,11 @@ class WgetAdapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var data in process.stderr.transform(utf8.decoder)) {
-      final lines = data.split('\n');
-      for (final line in lines) {
-        onProgress?.call(parseProgress(line));
-      }
+    await for (var line
+        in process.stderr
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())) {
+      onProgress?.call(parseProgress(line));
     }
 
     final exitCode = await process.exitCode;


### PR DESCRIPTION
Fixes an issue where parsing progress strings from CLI adapters (`Aria2Adapter`, `AxelAdapter`, `CurlAdapter`, `PowerShellAdapter`, `WgetAdapter`) could fail or produce incorrect updates because the underlying stream yields arbitrary chunks of text. 

Using `dart:convert`'s `LineSplitter()` guarantees that the `parseProgress` functions will only receive complete lines from the standard output and standard error streams. This improves the reliability of the progress callbacks and avoids bugs during parsing.

**Files changed:**
- `lib/src/adapters/aria2.dart`
- `lib/src/adapters/axel.dart`
- `lib/src/adapters/curl.dart`
- `lib/src/adapters/powershell.dart`
- `lib/src/adapters/wget.dart`

No markdown files were modified since this is an internal refactor/bug fix that does not alter public behavior or documentation. Tests have been verified to pass locally.

---
*PR created automatically by Jules for task [7917624032791682953](https://jules.google.com/task/7917624032791682953) started by @insign*