### PR TITLE
fix: use LineSplitter for reliable progress parsing in CLI adapters

### DIFF
--- a/lib/src/adapters/aria2.dart
+++ b/lib/src/adapters/aria2.dart
@@ -74,11 +74,8 @@ class Aria2Adapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var data in process.stdout.transform(utf8.decoder)) {
-      final lines = data.split('\n');
-      for (final line in lines) {
-        onProgress?.call(parseProgress(line));
-      }
+    await for (var line in process.stdout.transform(utf8.decoder).transform(const LineSplitter())) {
+      onProgress?.call(parseProgress(line));
     }
 
     final exitCode = await process.exitCode;

--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -60,11 +60,8 @@ class AxelAdapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var data in process.stdout.transform(utf8.decoder)) {
-      final lines = data.split('\n');
-      for (final line in lines) {
-        onProgress?.call(parseProgress(line));
-      }
+    await for (var line in process.stdout.transform(utf8.decoder).transform(const LineSplitter())) {
+      onProgress?.call(parseProgress(line));
     }
 
     final exitCode = await process.exitCode;

--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -60,12 +60,9 @@ class CurlAdapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var data in process.stderr.transform(utf8.decoder)) {
-      final lines = data.split(RegExp(r'[\n\r]'));
-      for (final line in lines) {
-        if (line.isNotEmpty) {
-          onProgress?.call(parseProgress(line));
-        }
+    await for (var line in process.stderr.transform(utf8.decoder).transform(const LineSplitter())) {
+      if (line.isNotEmpty) {
+        onProgress?.call(parseProgress(line));
       }
     }
 

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -52,11 +52,8 @@ class PowerShellAdapter implements DloaderAdapter {
       'Start-BitsTransfer -Source $url -Destination ${destination.path} ${userAgent != null ? "-UserAgent $userAgent" : ""}}',
     ]);
 
-    await for (var data in process.stdout.transform(utf8.decoder)) {
-      final lines = data.split('\n');
-      for (final line in lines) {
-        onProgress?.call(parseProgress(line));
-      }
+    await for (var line in process.stdout.transform(utf8.decoder).transform(const LineSplitter())) {
+      onProgress?.call(parseProgress(line));
     }
 
     final exitCode = await process.exitCode;

--- a/lib/src/adapters/wget.dart
+++ b/lib/src/adapters/wget.dart
@@ -58,11 +58,8 @@ class WgetAdapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var data in process.stderr.transform(utf8.decoder)) {
-      final lines = data.split('\n');
-      for (final line in lines) {
-        onProgress?.call(parseProgress(line));
-      }
+    await for (var line in process.stderr.transform(utf8.decoder).transform(const LineSplitter())) {
+      onProgress?.call(parseProgress(line));
     }
 
     final exitCode = await process.exitCode;


### PR DESCRIPTION
This PR introduces a targeted bug fix to improve the reliability of progress event parsing across all CLI-based download adapters (Aria2, Axel, Curl, PowerShell, Wget).

### The issue
Previously, the code listened to process streams (`stdout`/`stderr`) by transforming the stream to UTF-8 and blindly calling `.split('\n')` on each chunk of string data. Because standard stream boundaries do not respect newlines (a chunk could end halfway through a progress percentage string), it is highly likely that fragmented strings were being fed into `parseProgress()`, leading to skipped or misparsed progress events.

### The solution
This PR replaces the manual `.split` implementations with `dart:convert`'s built-in `LineSplitter()`. `LineSplitter` inherently handles buffering chunks until a valid newline sequence (`\r`, `\n`, or `\r\n`) is encountered, guaranteeing that `parseProgress` only processes complete, well-formed string outputs.

This single improvement brings concrete value by hardening the application against unpredictable stream splits and ensuring accurate progress updates. No other irrelevant changes were made. Tests were verified to ensure existing behavior works perfectly.

---
*PR created automatically by Jules for task [1897349162596728681](https://jules.google.com/task/1897349162596728681) started by @insign*