### PR TITLE
fix: fix PowerShellAdapter syntax and add path quoting

### DIFF
--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:executable/executable.dart';
 
 import '../dloader_adapter.dart';
+import '../utils/powershell_utils.dart';
 
 /// This class implements [DloaderAdapter] for downloading using powershell.
 class PowerShellAdapter implements DloaderAdapter {
@@ -47,11 +48,15 @@ class PowerShellAdapter implements DloaderAdapter {
       );
     }
     executablePath ??= (await executable.find())!;
+
+    final escapedUrl = PowerShellUtils.escapeLiteral(url);
+    final escapedDest = PowerShellUtils.escapeLiteral(destination.path);
     final String userAgentArg = userAgent != null
-        ? '-UserAgent "$userAgent"'
+        ? '-UserAgent ${PowerShellUtils.escapeLiteral(userAgent)}'
         : '';
+
     final String command =
-        'Start-BitsTransfer -Source "$url" -Destination "${destination.path}" $userAgentArg'
+        'Start-BitsTransfer -Source $escapedUrl -Destination $escapedDest $userAgentArg'
             .trim();
 
     final process = await Process.start(executablePath!, ['-Command', command]);

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -47,12 +47,19 @@ class PowerShellAdapter implements DloaderAdapter {
       );
     }
     executablePath ??= (await executable.find())!;
-    final process = await Process.start(executablePath!, [
-      '-Command',
-      'Start-BitsTransfer -Source $url -Destination ${destination.path} ${userAgent != null ? "-UserAgent $userAgent" : ""}}',
-    ]);
+    final String userAgentArg = userAgent != null
+        ? '-UserAgent "$userAgent"'
+        : '';
+    final String command =
+        'Start-BitsTransfer -Source "$url" -Destination "${destination.path}" $userAgentArg'
+            .trim();
 
-    await for (var line in process.stdout.transform(utf8.decoder).transform(const LineSplitter())) {
+    final process = await Process.start(executablePath!, ['-Command', command]);
+
+    await for (var line
+        in process.stdout
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())) {
       onProgress?.call(parseProgress(line));
     }
 

--- a/lib/src/utils/powershell_utils.dart
+++ b/lib/src/utils/powershell_utils.dart
@@ -1,0 +1,9 @@
+/// Utility functions for PowerShell.
+class PowerShellUtils {
+  /// Escapes a string to be safely used as a literal string in PowerShell.
+  /// It wraps the string in single quotes and escapes any internal single quotes by doubling them.
+  static String escapeLiteral(String value) {
+    final escaped = value.replaceAll("'", "''");
+    return "'$escaped'";
+  }
+}

--- a/test/powershell_utils_test.dart
+++ b/test/powershell_utils_test.dart
@@ -1,0 +1,14 @@
+import 'package:dloader/src/utils/powershell_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('escapeLiteral escapes single quotes', () {
+    expect(PowerShellUtils.escapeLiteral("test"), "'test'");
+    expect(PowerShellUtils.escapeLiteral("test's"), "'test''s'");
+    expect(PowerShellUtils.escapeLiteral("hello \$world"), "'hello \$world'");
+    expect(
+      PowerShellUtils.escapeLiteral("C:\\My Files & Folder\\"),
+      "'C:\\My Files & Folder\\'",
+    );
+  });
+}


### PR DESCRIPTION
Fixed a critical bug in the PowerShellAdapter. The previous implementation had a stray trailing brace (`}`) in the command string, which caused syntax errors in PowerShell. Furthermore, paths and URLs were unquoted, breaking execution on paths with spaces. This change correctly constructs the command string with proper quotes.

This improves the reliability and correctness of the `PowerShellAdapter`.

---
*PR created automatically by Jules for task [13952768382001072018](https://jules.google.com/task/13952768382001072018) started by @insign*