### PR TITLE
fix: prevent zombie processes in CLI adapters

### DIFF
--- a/lib/src/adapters/aria2.dart
+++ b/lib/src/adapters/aria2.dart
@@ -74,16 +74,20 @@ class Aria2Adapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var line in process.stdout.transform(utf8.decoder).transform(const LineSplitter())) {
-      onProgress?.call(parseProgress(line));
-    }
+    try {
+      await for (var line in process.stdout.transform(utf8.decoder).transform(const LineSplitter())) {
+        onProgress?.call(parseProgress(line));
+      }
 
-    final exitCode = await process.exitCode;
-    if (exitCode != 0) {
-      throw Exception('aria2c exited with code $exitCode');
-    }
+      final exitCode = await process.exitCode;
+      if (exitCode != 0) {
+        throw Exception('aria2c exited with code $exitCode');
+      }
 
-    return destination;
+      return destination;
+    } finally {
+      process.kill();
+    }
   }
 
   /// Parses the progress string output by the aria2c executable and returns a [Map] containing the progress information.

--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -60,16 +60,20 @@ class AxelAdapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var line in process.stdout.transform(utf8.decoder).transform(const LineSplitter())) {
-      onProgress?.call(parseProgress(line));
-    }
+    try {
+      await for (var line in process.stdout.transform(utf8.decoder).transform(const LineSplitter())) {
+        onProgress?.call(parseProgress(line));
+      }
 
-    final exitCode = await process.exitCode;
-    if (exitCode != 0) {
-      throw Exception('axel exited with code $exitCode');
-    }
+      final exitCode = await process.exitCode;
+      if (exitCode != 0) {
+        throw Exception('axel exited with code $exitCode');
+      }
 
-    return destination;
+      return destination;
+    } finally {
+      process.kill();
+    }
   }
 
   /// Parses the progress string from axel and returns a [Map] with the progress information.

--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -60,18 +60,22 @@ class CurlAdapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var line in process.stderr.transform(utf8.decoder).transform(const LineSplitter())) {
-      if (line.isNotEmpty) {
-        onProgress?.call(parseProgress(line));
+    try {
+      await for (var line in process.stderr.transform(utf8.decoder).transform(const LineSplitter())) {
+        if (line.isNotEmpty) {
+          onProgress?.call(parseProgress(line));
+        }
       }
-    }
 
-    final exitCode = await process.exitCode;
-    if (exitCode != 0) {
-      throw Exception('curl exited with code $exitCode');
-    }
+      final exitCode = await process.exitCode;
+      if (exitCode != 0) {
+        throw Exception('curl exited with code $exitCode');
+      }
 
-    return destination;
+      return destination;
+    } finally {
+      process.kill();
+    }
   }
 
   /// Parses the progress string from curl and returns a [Map] with the progress

--- a/lib/src/adapters/powershell.dart
+++ b/lib/src/adapters/powershell.dart
@@ -61,19 +61,23 @@ class PowerShellAdapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, ['-Command', command]);
 
-    await for (var line
-        in process.stdout
-            .transform(utf8.decoder)
-            .transform(const LineSplitter())) {
-      onProgress?.call(parseProgress(line));
-    }
+    try {
+      await for (var line
+          in process.stdout
+              .transform(utf8.decoder)
+              .transform(const LineSplitter())) {
+        onProgress?.call(parseProgress(line));
+      }
 
-    final exitCode = await process.exitCode;
-    if (exitCode != 0) {
-      throw Exception('powershell exited with code $exitCode');
-    }
+      final exitCode = await process.exitCode;
+      if (exitCode != 0) {
+        throw Exception('powershell exited with code $exitCode');
+      }
 
-    return destination;
+      return destination;
+    } finally {
+      process.kill();
+    }
   }
 
   /// Parses the progress string from the powershell output.

--- a/lib/src/adapters/wget.dart
+++ b/lib/src/adapters/wget.dart
@@ -58,16 +58,20 @@ class WgetAdapter implements DloaderAdapter {
 
     final process = await Process.start(executablePath!, args);
 
-    await for (var line in process.stderr.transform(utf8.decoder).transform(const LineSplitter())) {
-      onProgress?.call(parseProgress(line));
-    }
+    try {
+      await for (var line in process.stderr.transform(utf8.decoder).transform(const LineSplitter())) {
+        onProgress?.call(parseProgress(line));
+      }
 
-    final exitCode = await process.exitCode;
-    if (exitCode != 0) {
-      throw Exception('wget exited with code $exitCode');
-    }
+      final exitCode = await process.exitCode;
+      if (exitCode != 0) {
+        throw Exception('wget exited with code $exitCode');
+      }
 
-    return destination;
+      return destination;
+    } finally {
+      process.kill();
+    }
   }
 
   /// Parses the progress string from wget.


### PR DESCRIPTION
This PR prevents external download processes (like curl, wget, aria2c, axel, powershell) from becoming orphaned zombie processes if a Dart exception occurs during execution. It achieves this by wrapping the output stream processing and `exitCode` awaits in a `try...finally` block that explicitly calls `process.kill()`.

By ensuring the spawned process is always terminated, we prevent background resource leaks in failure scenarios. Calling `process.kill()` in Dart is safe because it simply returns `false` (no-op) if the process has already completed normally.

---
*PR created automatically by Jules for task [9253334282535353255](https://jules.google.com/task/9253334282535353255) started by @insign*