### PR TITLE
fix: Enable download resuming for AxelAdapter

### DIFF
--- a/lib/src/adapters/axel.dart
+++ b/lib/src/adapters/axel.dart
@@ -40,10 +40,6 @@ class AxelAdapter implements DloaderAdapter {
   }) async {
     executablePath ??= (await executable.find())!;
 
-    if (destination.existsSync()) {
-      destination.deleteSync();
-    }
-
     final args = [
       url,
       '--num-connections=$segments',

--- a/test/dloader_test.dart
+++ b/test/dloader_test.dart
@@ -135,6 +135,14 @@ void main() {
 
     print('Using adapter: ${dloader.adapter.runtimeType}');
 
+    if (destination.existsSync()) {
+      destination.deleteSync();
+    }
+    final stFile = File('${destination.path}.st');
+    if (stFile.existsSync()) {
+      stFile.deleteSync();
+    }
+
     try {
       final file = await dloader.download(
         url: url,


### PR DESCRIPTION
This PR enables `AxelAdapter` to resume interrupted downloads by no longer explicitly deleting the destination file before execution. This prevents data loss on retry and correctly leverages Axel's `.st` state files, offering a highly practical improvement in network performance and reliability for users.

I chose this improvement because `AxelAdapter` is the second-highest priority adapter chosen by `Dloader.auto()`. Its previous behavior destroyed partial downloads, actively contradicting its own core capability to resume them. 

Files modified:
- `lib/src/adapters/axel.dart`: Removed `if (destination.existsSync()) destination.deleteSync();` to allow the underlying `axel` command to evaluate and utilize the existing file and state.
- `test/dloader_test.dart`: Updated the `.auto()` test to explicitly clean up the target file and any `.st` file so the tests remain completely deterministic and idempotent.

There were no necessary `.md` changes as the README does not explicitly document adapter state management that was contradicted by this fix. All 15 tests pass successfully. No temporary files were added or committed.

---
*PR created automatically by Jules for task [85026048373051429](https://jules.google.com/task/85026048373051429) started by @insign*