### PR TITLE
Fix Curl adapter progress parsing to report correct downloaded bytes

### DIFF
--- a/lib/src/adapters/curl.dart
+++ b/lib/src/adapters/curl.dart
@@ -87,7 +87,7 @@ class CurlAdapter implements DloaderAdapter {
     if (match != null && match.groupCount == 12) {
       progress["percentComplete"] = match.group(1)!;
       progress["totalSize"] = match.group(2)!;
-      progress["downloaded"] = match.group(3)!;
+      progress["downloaded"] = match.group(4)!;
       progress["averageSpeed"] = match.group(7)!;
       progress["totalTime"] = match.group(9)!;
       progress["spentTime"] = match.group(10)!;


### PR DESCRIPTION
Fix Curl adapter progress parsing to report correct downloaded bytes. This provides accurate progress information to users instead of reporting the percentage twice.

The `CurlAdapter` in `lib/src/adapters/curl.dart` incorrectly parsed the output of `curl` progress. Specifically, the field `progress["downloaded"]` was assigned the 3rd matched regex group (`match.group(3)`), which actually corresponds to `% Received` (which is equal to `% Total` for downloads, i.e., the percentage complete). The true downloaded bytes amount (`Received`) corresponds to the 4th matched group (`match.group(4)`).

This change assigns `progress["downloaded"]` the value of `match.group(4)`. Tests have been run and they pass successfully.

---
*PR created automatically by Jules for task [6160023492667211831](https://jules.google.com/task/6160023492667211831) started by @insign*