### PR TITLE
test: add invalid URL tests for aria2 and axel adapters

### DIFF
--- a/test/dloader_test.dart
+++ b/test/dloader_test.dart
@@ -38,6 +38,42 @@ void main() {
     }, throwsException);
   });
 
+  test('Test Dloader with Aria2Adapter and invalid URL', () async {
+    final adapter = Aria2Adapter();
+    if (!adapter.isAvailable) {
+      print('Skipping test: aria2c not available');
+      return;
+    }
+
+    await expectLater(() async {
+      final dloader = Dloader(adapter);
+      final destination = File('${Directory.systemTemp.path}/aria2_invalid.dat');
+
+      await dloader.download(
+        url: 'https://invalid.supersite/file.dat',
+        destination: destination,
+      );
+    }, throwsException);
+  });
+
+  test('Test Dloader with AxelAdapter and invalid URL', () async {
+    final adapter = AxelAdapter();
+    if (!adapter.isAvailable) {
+      print('Skipping test: axel not available');
+      return;
+    }
+
+    await expectLater(() async {
+      final dloader = Dloader(adapter);
+      final destination = File('${Directory.systemTemp.path}/axel_invalid.dat');
+
+      await dloader.download(
+        url: 'https://invalid.supersite/file.dat',
+        destination: destination,
+      );
+    }, throwsException);
+  });
+
   test('Test Dloader reuse CurlAdapter', () async {
     final adapter = CurlAdapter();
     if (!adapter.isAvailable) {


### PR DESCRIPTION
This PR adds invalid URL tests for `Aria2Adapter` and `AxelAdapter`.

By adding these test cases, we increase the test coverage for failure states and ensure that these adapters correctly throw exceptions when a download fails due to an invalid URL, which improves the reliability of the test suite and prevents regressions in error handling.

---
*PR created automatically by Jules for task [1518632746683950300](https://jules.google.com/task/1518632746683950300) started by @insign*