### PR TITLE
fix: prevent download crash when segments is set to 0

### DIFF
--- a/lib/src/dloader_base.dart
+++ b/lib/src/dloader_base.dart
@@ -82,6 +82,9 @@ class Dloader {
     }
 
     segments = (segments ?? 1).abs();
+    if (segments == 0) {
+      segments = 1;
+    }
 
     if (url.isEmpty) {
       throw Exception('URL not provided');

--- a/test/dloader_test.dart
+++ b/test/dloader_test.dart
@@ -237,4 +237,29 @@ void main() {
       }
     },
   );
+
+  test('Test Dloader with segments: 0', () async {
+    final dloader = Dloader.auto();
+    final url = 'https://proof.ovh.net/files/1Mb.dat';
+    final destination = File('${Directory.systemTemp.path}/segments_0.dat');
+
+    try {
+      if (destination.existsSync()) {
+        destination.deleteSync();
+      }
+
+      final file = await dloader.download(
+        url: url,
+        destination: destination,
+        segments: 0,
+      );
+
+      expect(file.existsSync(), true);
+      expect(file.lengthSync(), 1048576);
+    } finally {
+      if (destination.existsSync()) {
+        destination.deleteSync();
+      }
+    }
+  });
 }


### PR DESCRIPTION
This PR fixes a bug where passing `segments: 0` to `Dloader.download()` would cause command-line download adapters (like `axel` and `aria2c`) to crash because they do not accept `0` as a valid number of connections. By falling back to `1` when `0` is passed, the reliability of the downloader is improved.

Changes made:
- Updated `lib/src/dloader_base.dart` to enforce a minimum of 1 segment (`if (segments == 0) { segments = 1; }`).
- Added a test case in `test/dloader_test.dart` to ensure downloads succeed even if `segments: 0` is passed.

---
*PR created automatically by Jules for task [11413751520676376673](https://jules.google.com/task/11413751520676376673) started by @insign*